### PR TITLE
Reduce the noise of default values in config files

### DIFF
--- a/lib/snapshot.sh
+++ b/lib/snapshot.sh
@@ -69,22 +69,24 @@ dump_config() {
 		fi
 	fi
 
-	# Emit YAML
-	echo "apps:"
-	if [[ ${#apps[@]} -gt 0 ]]; then
-		local a
-		for a in "${apps[@]}"; do printf '  - %s\n' "$a"; done
-	fi
-	if [[ -n "$dl_section_found" && -n "$norm_dl" ]]; then
-		cat <<EOF
+	# Emit YAML (strip defaults afterwards)
+	{
+		echo "apps:"
+		if [[ ${#apps[@]} -gt 0 ]]; then
+			local a
+			for a in "${apps[@]}"; do printf '  - %s\n' "$a"; done
+		fi
+		if [[ -n "$dl_section_found" && -n "$norm_dl" ]]; then
+			cat <<EOF
 downloads:
   preset: classic
   path: "$norm_dl"
   section: $dl_section_found
 EOF
-	else
-		echo "downloads: off"
-	fi
+		else
+			echo "downloads: off"
+		fi
+	} | strip_config_defaults_yaml
 }
 
 backup_to_file() {


### PR DESCRIPTION
This PR removes the complexity of default values by encapsulating this into the `config.sh` file. It does this in two ways:
- when the config is read, default values are auto-injected in, so that downstream systems do not need to worry about them
- when config is output (`show` and `backup` commands), the default values are removed so that they do not create noise

This is a precursor to issue #1, as it will require a lot of use of default values to optimise the calls made to the OS